### PR TITLE
Update behavior of RollingLineBuffer

### DIFF
--- a/rolling_line_buffer.go
+++ b/rolling_line_buffer.go
@@ -10,18 +10,26 @@ import (
 // stores the N most recent lines (delimited with '\n') written to it. Reads are
 // done forward-only; it does not implement io.Seeker.
 type RollingLineBuffer struct {
-	m        sync.Mutex
-	buf      [][]byte
-	capacity int
-	readpos  int
+	m          sync.Mutex
+	curLine    []byte
+	buf        [][]byte
+	capacity   int
+	readpos    int
+	lossyReads bool
+	delim      string
 }
 
 // NewRollingLineBuffer returns a new RollingLineBuffer that holds `capacity`
-// most recently-written lines.
+// most recently-written lines. Buffers writes until a '\n' is encountered.
 func NewRollingLineBuffer(capacity int) *RollingLineBuffer {
+	return NewRollingLineBufferWithDelimiter(capacity, "\n")
+}
+
+func NewRollingLineBufferWithDelimiter(capacity int, delimiter string) *RollingLineBuffer {
 	return &RollingLineBuffer{
 		buf:      make([][]byte, 0, capacity),
 		capacity: capacity,
+		delim:    delimiter,
 	}
 }
 
@@ -29,6 +37,10 @@ var (
 	_ io.Reader = (*RollingLineBuffer)(nil)
 	_ io.Writer = (*RollingLineBuffer)(nil)
 )
+
+func (rb *RollingLineBuffer) LossyReads() bool {
+	return rb.lossyReads
+}
 
 // Read implements io.Reader for RollingLineBuffer. Read reads one or more full
 // lines into buf and returns according to the io.Reader specification. If buf
@@ -41,38 +53,82 @@ func (rb *RollingLineBuffer) Read(buf []byte) (int, error) {
 	if len(rb.buf) == 0 {
 		return 0, nil
 	}
-
-	if len(rb.buf[rb.readpos]) > len(buf) {
-		return 0, &ErrShortBuffer{minimumSize: len(rb.buf[rb.readpos])}
+	if rb.readpos == len(rb.buf) {
+		return 0, io.EOF
 	}
 
-	tmp := make([]byte, 0, len(buf))
+	if len(rb.buf[rb.readpos])+len(rb.delim) > len(buf) {
+		return 0, &ErrShortBuffer{minimumSize: len(rb.buf[rb.readpos]) + len(rb.delim)}
+	}
+
+	tmp := make([]byte, 0, len(buf)+len(rb.delim))
 	read := 0
 	for rb.readpos < len(rb.buf) {
-		if read+len(rb.buf[rb.readpos]) > len(buf) {
+		if read+(len(rb.buf[rb.readpos])+len(rb.delim)) > len(buf) {
 			break
 		}
 
 		tmp = append(tmp, rb.buf[rb.readpos]...)
+		tmp = append(tmp, []byte(rb.delim)...)
+		read += len(rb.buf[rb.readpos]) + len(rb.delim)
 		rb.readpos++
 	}
 
+	rb.lossyReads = false
 	return copy(buf, tmp), nil
 }
 
 // Write implements io.Writer for RollingLineBuffer.
 func (rb *RollingLineBuffer) Write(data []byte) (int, error) {
-	lines := bytes.Split(data, []byte{'\n'})
+	lines := bytes.Split(data, []byte(rb.delim))
+	lastIdx := bytes.LastIndex(data, []byte(rb.delim))
+
+	// is the data being written flushable?
+	flushableLastLine := false
+	if lastIdx == (len(data) - len(rb.delim)) {
+		flushableLastLine = true
+		// strip the last "" that comes from bytes.Split when the last segment is
+		// a delimeter
+		lines = lines[:len(lines)-1]
+	}
+
+	if len(lines) == 0 {
+		return 0, nil
+	}
 
 	rb.m.Lock()
 	defer rb.m.Unlock()
 
-	rb.buf = append(rb.buf, lines...)
+	switch {
+	case !flushableLastLine && len(lines) == 1:
+		// the last line is not flushable, and no full lines created so just
+		// append to the growing buffer and bail
+		rb.curLine = append(rb.curLine, lines[0]...)
+		lines = nil
+
+	case len(rb.curLine) > 0:
+		// we have a current line in progress that should be flushed
+		rb.curLine = append(rb.curLine, lines[0]...)
+		lines = lines[1:]
+		rb.buf = append(rb.buf, rb.curLine)
+		rb.curLine = nil
+	}
+
+	if len(lines) > 0 {
+		if flushableLastLine {
+			rb.buf = append(rb.buf, lines...)
+		} else {
+			rb.buf = append(rb.buf, lines[:len(lines)-1]...)
+			rb.curLine = lines[len(lines)-1]
+		}
+	}
+
 	if len(rb.buf) > rb.capacity {
 		shift := len(rb.buf) - rb.capacity
 		rb.buf = rb.buf[shift:]
 		rb.readpos -= shift
 		if rb.readpos < 0 {
+			rb.lossyReads = true
 			rb.readpos = 0
 		}
 	}

--- a/rolling_line_buffer.go
+++ b/rolling_line_buffer.go
@@ -65,11 +65,8 @@ func (rb *RollingLineBuffer) Read(buf []byte) (int, error) {
 	rb.m.Lock()
 	defer rb.m.Unlock()
 
-	if len(rb.buf) == 0 {
+	if len(rb.buf) == 0 || rb.readpos >= len(rb.buf) {
 		return 0, nil
-	}
-	if rb.readpos == len(rb.buf) {
-		return 0, io.EOF
 	}
 
 	if len(rb.buf[rb.readpos])+len(rb.delim) > len(buf) {

--- a/rolling_line_buffer_test.go
+++ b/rolling_line_buffer_test.go
@@ -1,15 +1,23 @@
 package miscio
 
-import "testing"
+import (
+	"io"
+	"testing"
+)
+
+func mustWrite(t *testing.T, rb *RollingLineBuffer, w []byte) {
+	t.Helper()
+	_, err := rb.Write(w)
+	if err != nil {
+		t.Fatalf("Failed to write to buffer: %s", err)
+	}
+}
 
 func TestRollingLineBuffer(t *testing.T) {
 	rb := NewRollingLineBuffer(2)
-	_, err := rb.Write([]byte("hello\nworld\ngoodbye"))
-	if err != nil {
-		t.Fatalf("Write failed with %s", err)
-	}
-
+	mustWrite(t, rb, []byte("hello\nworld\ngoodbye\n"))
 	assertBufferContents(t, []string{"world", "goodbye"}, rb)
+	assertPartialLine(t, nil, rb)
 }
 
 func assertBufferContents(t *testing.T, expectedBuffer []string, rb *RollingLineBuffer) {
@@ -17,7 +25,6 @@ func assertBufferContents(t *testing.T, expectedBuffer []string, rb *RollingLine
 
 	if len(rb.buf) != len(expectedBuffer) {
 		t.Errorf("assertBufferContents: should have %d elements, got %d", len(expectedBuffer), len(rb.buf))
-		return
 	}
 
 	for i, expected := range expectedBuffer {
@@ -25,4 +32,113 @@ func assertBufferContents(t *testing.T, expectedBuffer []string, rb *RollingLine
 			t.Errorf("assertBufferContents mismatch at pos %d; got %v want %v", i, string(rb.buf[i]), expected)
 		}
 	}
+}
+
+func assertPartialLine(t *testing.T, want []byte, rb *RollingLineBuffer) {
+	t.Helper()
+	if len(want) != len(rb.curLine) {
+		t.Errorf("assertPartialLine: expected partial line length %d, got %d", len(want), len(rb.curLine))
+		return
+	}
+	if string(want) != string(rb.curLine) {
+		t.Errorf("assertPartialLine: expected partial line to be '%v', got '%v'", []byte(want), rb.curLine)
+	}
+}
+
+func TestRLBPartialWrite(t *testing.T) {
+	rb := NewRollingLineBuffer(2)
+
+	mustWrite(t, rb, []byte("a123456789\nb1234\nc1234567"))
+	assertBufferContents(t, []string{"a123456789", "b1234"}, rb)
+	assertPartialLine(t, []byte("c1234567"), rb)
+
+	mustWrite(t, rb, []byte("89\naoeu"))
+	assertBufferContents(t, []string{"b1234", "c123456789"}, rb)
+	assertPartialLine(t, []byte("aoeu"), rb)
+
+	mustWrite(t, rb, []byte("\n"))
+	assertBufferContents(t, []string{"c123456789", "aoeu"}, rb)
+	assertPartialLine(t, nil, rb)
+}
+
+func assertReadResults(t *testing.T, want string, got []byte, wantN, gotN int, wantErr, gotErr error) {
+	t.Helper()
+	gotString := string(got)
+	if gotN > 0 {
+		gotString = string(got[:gotN])
+	}
+	// only compare strings if we actually expected to read something
+	if wantN > 0 && want != gotString {
+		t.Errorf("Expected read buffer to contain '%v', got '%v'", []byte(want), got)
+	}
+	if wantN != gotN {
+		t.Errorf("Expected bytes read to be %d, got %d", wantN, gotN)
+	}
+	if wantErr != gotErr {
+		t.Errorf("Expected read error to be %v, got %v", wantErr, gotErr)
+	}
+}
+
+func TestRLBReadToEnd(t *testing.T) {
+	rb := NewRollingLineBuffer(2)
+	mustWrite(t, rb, []byte("a123456789\nb123456789\nc123456789\n"))
+	assertBufferContents(t, []string{"b123456789", "c123456789"}, rb)
+	assertPartialLine(t, nil, rb)
+
+	b := make([]byte, 12)
+	n, err := rb.Read(b)
+	assertReadResults(t, "b123456789\n", b, 11, n, nil, err)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "c123456789\n", b, 11, n, nil, err)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "c123456789\n", b, 0, n, io.EOF, err)
+}
+
+func TestRLBPartialRead(t *testing.T) {
+	rb := NewRollingLineBuffer(2)
+	mustWrite(t, rb, []byte("a123456789\nb1234\nc1234567"))
+	assertBufferContents(t, []string{"a123456789", "b1234"}, rb)
+	assertPartialLine(t, []byte("c1234567"), rb)
+
+	b := make([]byte, 12)
+	n, err := rb.Read(b)
+	assertReadResults(t, "a123456789\n", b, 11, n, nil, err)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "b1234\n", b, 6, n, nil, err)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "", b, 0, n, io.EOF, err)
+
+	mustWrite(t, rb, []byte("89\naoeu"))
+	assertBufferContents(t, []string{"b1234", "c123456789"}, rb)
+	assertPartialLine(t, []byte("aoeu"), rb)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "c123456789\n", b, 11, n, nil, err)
+
+	mustWrite(t, rb, []byte("\n"))
+	assertBufferContents(t, []string{"c123456789", "aoeu"}, rb)
+	assertPartialLine(t, nil, rb)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "aoeu\n", b, 5, n, nil, err)
+
+	n, err = rb.Read(b)
+	assertReadResults(t, "", b, 0, n, io.EOF, err)
+}
+
+func TestRLBAllNewlines(t *testing.T) {
+	rb := NewRollingLineBuffer(5)
+	mustWrite(t, rb, []byte("\n\n\n\n\n\n\n\n\n"))
+	assertBufferContents(t, []string{"", "", "", "", ""}, rb)
+	assertPartialLine(t, nil, rb)
+
+	b := make([]byte, 100)
+	n, err := rb.Read(b)
+	assertReadResults(t, "\n\n\n\n\n", b, 5, n, nil, err)
+	n, err = rb.Read(b)
+	assertReadResults(t, "", b, 0, n, io.EOF, err)
 }

--- a/rolling_line_buffer_test.go
+++ b/rolling_line_buffer_test.go
@@ -1,7 +1,6 @@
 package miscio
 
 import (
-	"io"
 	"testing"
 )
 
@@ -94,7 +93,7 @@ func TestRLBReadToEnd(t *testing.T) {
 	assertReadResults(t, "c123456789\n", b, 11, n, nil, err)
 
 	n, err = rb.Read(b)
-	assertReadResults(t, "c123456789\n", b, 0, n, io.EOF, err)
+	assertReadResults(t, "c123456789\n", b, 0, n, nil, err)
 }
 
 func TestRLBPartialRead(t *testing.T) {
@@ -111,7 +110,7 @@ func TestRLBPartialRead(t *testing.T) {
 	assertReadResults(t, "b1234\n", b, 6, n, nil, err)
 
 	n, err = rb.Read(b)
-	assertReadResults(t, "", b, 0, n, io.EOF, err)
+	assertReadResults(t, "", b, 0, n, nil, err)
 
 	mustWrite(t, rb, []byte("89\naoeu"))
 	assertBufferContents(t, []string{"b1234", "c123456789"}, rb)
@@ -128,7 +127,7 @@ func TestRLBPartialRead(t *testing.T) {
 	assertReadResults(t, "aoeu\n", b, 5, n, nil, err)
 
 	n, err = rb.Read(b)
-	assertReadResults(t, "", b, 0, n, io.EOF, err)
+	assertReadResults(t, "", b, 0, n, nil, err)
 }
 
 func TestRLBAllNewlines(t *testing.T) {
@@ -141,5 +140,5 @@ func TestRLBAllNewlines(t *testing.T) {
 	n, err := rb.Read(b)
 	assertReadResults(t, "\n\n\n\n\n", b, 5, n, nil, err)
 	n, err = rb.Read(b)
-	assertReadResults(t, "", b, 0, n, io.EOF, err)
+	assertReadResults(t, "", b, 0, n, nil, err)
 }

--- a/rolling_line_buffer_test.go
+++ b/rolling_line_buffer_test.go
@@ -65,6 +65,7 @@ func assertReadResults(t *testing.T, want string, got []byte, wantN, gotN int, w
 	t.Helper()
 	gotString := string(got)
 	if gotN > 0 {
+		// truncate data that wasn't written when we convert into a string
 		gotString = string(got[:gotN])
 	}
 	// only compare strings if we actually expected to read something


### PR DESCRIPTION
This is a pretty major impl change so ignore if you want but it also fixes a bug:

```golang
if len(rb.buf[rb.readpos]) > len(buf) {
    return 0, &ErrShortBuffer{minimumSize: len(rb.buf[rb.readpos])}
```

The above code fails because it's missing an `if rb.readpos == len(buf) { return 0, nil }` which is how I started poking at making changes. Additional changes are by preference so TIOLI.

On top of the above bug fix the comments suggested that you wouldn't get a partial line back ("Read reads one or more full lines into buf") which, as far as I could tell, wasn't enforced in the case of a partial-line Write call. So thinking through the headache of tracking partial line reads/writes and how to signal to a reader (should they even care if they're using this?) I ended up just heading to this version.

Obvious problems exist in that buf could ground without bound but maybe don't use this in cases where that could happen.

Added some tests, it should still work :sweat_smile: 